### PR TITLE
feat: add typed models, variables-values API, and FillEnvVarsAsync with cache fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with: { dotnet-version: '8.0.x' }
 
       - run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with: { dotnet-version: '8.0.x' }
 
       - name: Semantic Release

--- a/Envbee.SDK.Tests/EnvbeeClientMainTests.cs
+++ b/Envbee.SDK.Tests/EnvbeeClientMainTests.cs
@@ -155,6 +155,147 @@ public class EnvbeeClientMainTests
         Assert.Equal(100, md.Total);
     }
 
+    [Fact]
+    public async Task GetVariablesTyped_Simple()
+    {
+        var payload = new
+        {
+            metadata = new { limit = 1, offset = 10, total = 100 },
+            data = new[]
+            {
+                new { id = 1, type = "STRING",  name = "VAR1", description = "desc1" },
+                new { id = 2, type = "BOOLEAN", name = "VAR2", description = "desc2" }
+            }
+        };
+
+        var client = CreateClient(_ => JsonResp(payload));
+        var (vars, md) = await client.GetVariablesTypedAsync();
+
+        Assert.Equal("desc1", vars.First(v => v.Name == "VAR1").Description);
+        Assert.Equal(VariableType.STRING, vars.First(v => v.Name == "VAR1").Type);
+        Assert.Equal(100, md.Total);
+    }
+
+    [Fact]
+    public async Task GetVariablesValuesTyped_Simple()
+    {
+        var payload = new
+        {
+            metadata = new { limit = 2, offset = 0, total = 2 },
+            data = new object[]
+            {
+                new { id = 1, variable_id = 1, content = new Dictionary<string, object> { ["value"] = "Value1" } },
+                new { id = 2, variable_id = 2, content = new Dictionary<string, object> { ["value"] = true } }
+            }
+        };
+
+        var client = CreateClient(_ => JsonResp(payload));
+        var (values, md) = await client.GetVariablesValuesTypedAsync();
+
+        Assert.Equal("Value1", values.First(v => v.VariableId == 1).Content.GetProperty("value").GetString());
+        Assert.True(values.First(v => v.VariableId == 2).Content.GetProperty("value").GetBoolean());
+        Assert.Equal(2, md.Total);
+    }
+
+    [Fact]
+    public async Task FillEnvVars_SetsEnvironmentVariables()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("VAR1", null);
+            Environment.SetEnvironmentVariable("VAR2", null);
+
+            var client = CreateClient(req =>
+            {
+                var path = req.RequestUri!.AbsolutePath;
+
+                if (path == "/v1/variables")
+                {
+                    return JsonResp(new
+                    {
+                        metadata = new { limit = 2, offset = 0, total = 2 },
+                        data = new[]
+                        {
+                            new { id = 1, name = "VAR1", type = "STRING", description = "desc1" },
+                            new { id = 2, name = "VAR2", type = "BOOLEAN", description = "desc2" }
+                        }
+                    });
+                }
+
+                if (path == "/v1/variables-values")
+                {
+                    return JsonResp(new
+                    {
+                        metadata = new { limit = 2, offset = 0, total = 2 },
+                        data = new object[]
+                        {
+                            new { id = 1, variable_id = 1, content = new Dictionary<string, object> { ["value"] = "Value1" } },
+                            new { id = 2, variable_id = 2, content = new Dictionary<string, object> { ["value"] = true } }
+                        }
+                    });
+                }
+
+                return JsonResp(new { }, HttpStatusCode.InternalServerError);
+            });
+
+            await client.FillEnvVarsAsync();
+
+            Assert.Equal("Value1", Environment.GetEnvironmentVariable("VAR1"));
+            Assert.Equal("True", Environment.GetEnvironmentVariable("VAR2"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("VAR1", null);
+            Environment.SetEnvironmentVariable("VAR2", null);
+        }
+    }
+
+    [Fact]
+    public async Task FillEnvVars_UsesCacheFallback()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("VAR1", null);
+            Environment.SetEnvironmentVariable("VAR2", null);
+
+            var cache = new MemoryCache();
+            var failFillRequests = false;
+
+            var client = CreateClient(req =>
+            {
+                var path = req.RequestUri!.AbsolutePath;
+
+                if (failFillRequests && (path == "/v1/variables" || path == "/v1/variables-values"))
+                    return JsonResp(new { }, HttpStatusCode.InternalServerError);
+
+                if (path == "/v1/variables-values-by-name/VAR1/content")
+                    return JsonResp(new { value = "ValueFromCache1" });
+
+                if (path == "/v1/variables-values-by-name/VAR2/content")
+                    return JsonResp(new { value = true });
+
+                if (path == "/v1/variables" || path == "/v1/variables-values")
+                    return JsonResp(new { }, HttpStatusCode.InternalServerError);
+
+                return JsonResp(new { }, HttpStatusCode.InternalServerError);
+            }, cacheStore: cache);
+
+            await client.GetAsync("VAR1");
+            await client.GetAsync("VAR2");
+
+            failFillRequests = true;
+            await client.FillEnvVarsAsync();
+
+            Assert.Equal("ValueFromCache1", Environment.GetEnvironmentVariable("VAR1"));
+            Assert.Equal("True", Environment.GetEnvironmentVariable("VAR2"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("VAR1", null);
+            Environment.SetEnvironmentVariable("VAR2", null);
+        }
+    }
+
     /* ---------- helper ---------- */
     private static EnvbeeClient CreateClient(
         Func<HttpRequestMessage, HttpResponseMessage?> responder,

--- a/Envbee.SDK.Tests/EnvbeeClientMainTests.cs
+++ b/Envbee.SDK.Tests/EnvbeeClientMainTests.cs
@@ -20,11 +20,19 @@ public class EnvbeeClientMainTests
     private sealed class FakeHttpHandler : HttpMessageHandler
     {
         public Func<HttpRequestMessage, HttpResponseMessage?>? Responder { get; set; }
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken _)
+        public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage?>>? AsyncResponder { get; set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
         {
+            if (AsyncResponder is not null)
+            {
+                var asyncResp = await AsyncResponder(req, ct);
+                return asyncResp ?? new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            }
+
             var resp = Responder?.Invoke(req) ??
                        new HttpResponseMessage(HttpStatusCode.InternalServerError);
-            return Task.FromResult(resp);
+            return resp;
         }
     }
 
@@ -130,6 +138,94 @@ public class EnvbeeClientMainTests
         var second = await client.GetAsync("Var1");
         Assert.Equal("ValueFromCache", first);
         Assert.Equal(first, second);      // proviene de cache
+    }
+
+    [Fact]
+    public async Task GetVariable_CachePath_CustomDirectory()
+    {
+        var customCachePath = Path.Combine(Path.GetTempPath(), $"envbee-test-cache-{Guid.NewGuid()}");
+
+        try
+        {
+            var client = CreateClient(
+                _ => JsonResp(new { value = "CustomPathValue" }),
+                cachePath: customCachePath);
+
+            var value = await client.GetAsync("VAR_CUSTOM_CACHE");
+            Assert.Equal("CustomPathValue", value);
+            Assert.True(File.Exists(Path.Combine(customCachePath, "variables.json")));
+        }
+        finally
+        {
+            if (Directory.Exists(customCachePath))
+                Directory.Delete(customCachePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task GetVariable_FallsBackToMemory_WhenCachePathIsInvalid()
+    {
+        var fileAsDirectoryPath = Path.GetTempFileName();
+        try
+        {
+            int call = 0;
+            var client = CreateClient(_ =>
+            {
+                if (Interlocked.Increment(ref call) == 1)
+                    return JsonResp(new { value = "ValueFromMemoryFallback" });
+
+                return JsonResp(new { }, HttpStatusCode.InternalServerError);
+            }, cachePath: fileAsDirectoryPath);
+
+            var first = await client.GetAsync("VAR_MEMORY_FALLBACK");
+            var second = await client.GetAsync("VAR_MEMORY_FALLBACK");
+
+            Assert.Equal("ValueFromMemoryFallback", first);
+            Assert.Equal("ValueFromMemoryFallback", second);
+        }
+        finally
+        {
+            if (File.Exists(fileAsDirectoryPath))
+                File.Delete(fileAsDirectoryPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetVariable_Timeout_FallsBackToCache()
+    {
+        var cache = new MemoryCache();
+        cache.Set("VAR_TIMEOUT", "CachedTimeoutValue");
+
+        var client = CreateClient(
+            _ => null,
+            asyncResponder: async (_, ct) =>
+            {
+                await Task.Delay(150, ct);
+                return JsonResp(new { value = "TooLate" });
+            },
+            cacheStore: cache,
+            timeoutSeconds: 0.01
+        );
+
+        var value = await client.GetAsync("VAR_TIMEOUT");
+        Assert.Equal("CachedTimeoutValue", value);
+    }
+
+    [Fact]
+    public async Task GetVariable_CustomTimeout_AllowsSlowResponse()
+    {
+        var client = CreateClient(
+            _ => null,
+            asyncResponder: async (_, ct) =>
+            {
+                await Task.Delay(30, ct);
+                return JsonResp(new { value = "Value1" });
+            },
+            timeoutSeconds: 1.0
+        );
+
+        var value = await client.GetAsync("VAR_TIMEOUT_OK");
+        Assert.Equal("Value1", value);
     }
 
     /* 7) get_variables simple */
@@ -299,10 +395,13 @@ public class EnvbeeClientMainTests
     /* ---------- helper ---------- */
     private static EnvbeeClient CreateClient(
         Func<HttpRequestMessage, HttpResponseMessage?> responder,
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage?>>? asyncResponder = null,
         Secret? encKey = null,
-        ICacheStore? cacheStore = null)
+        ICacheStore? cacheStore = null,
+        string? cachePath = null,
+        double? timeoutSeconds = null)
     {
-        var handler = new FakeHttpHandler { Responder = responder };
+        var handler = new FakeHttpHandler { Responder = responder, AsyncResponder = asyncResponder };
 
         // Build the client fluently
         var builder = EnvbeeClientBuilder.Create()
@@ -312,6 +411,12 @@ public class EnvbeeClientMainTests
 
         if (encKey is { } key)
             builder.WithEncryptionKey(key);
+
+        if (!string.IsNullOrEmpty(cachePath))
+            builder.WithCachePath(cachePath);
+
+        if (timeoutSeconds.HasValue)
+            builder.WithTimeoutSeconds(timeoutSeconds.Value);
 
         var client = builder.Build();
 

--- a/Envbee.SDK.Tests/Testing/MemoryCache.cs
+++ b/Envbee.SDK.Tests/Testing/MemoryCache.cs
@@ -8,4 +8,5 @@ public sealed class MemoryCache : ICacheStore
     private readonly ConcurrentDictionary<string, string> _dict = new();
     public string? Get(string k) => _dict.TryGetValue(k, out var v) ? v : null;
     public void Set(string k, string v) => _dict[k] = v;
+    public IEnumerable<KeyValuePair<string, string>> GetAll() => _dict.ToArray();
 }

--- a/Envbee.SDK/EnvbeeClient.cs
+++ b/Envbee.SDK/EnvbeeClient.cs
@@ -29,16 +29,19 @@ public sealed class EnvbeeClient
     private readonly AesGcm? _aesGcm;
     private readonly ILogger _logger;
     private readonly ICacheStore _cache;
+    private readonly TimeSpan _requestTimeout;
     private static HttpClient _http = new()
     {
-        Timeout = TimeSpan.FromSeconds(4)
+        Timeout = Timeout.InfiniteTimeSpan
     };
 
     private static readonly JsonSerializerOptions serializerOptions = new() { PropertyNameCaseInsensitive = true };
 
     internal static void OverrideHttpClient(HttpClient custom)
     {
-        _http = custom ?? throw new ArgumentNullException(nameof(custom));
+        if (custom is null) throw new ArgumentNullException(nameof(custom));
+        custom.Timeout = Timeout.InfiniteTimeSpan;
+        _http = custom;
     }
 
 
@@ -50,7 +53,9 @@ public sealed class EnvbeeClient
         string? apiKey = null,
         Secret apiSecret = default,
         Secret encKey = default,
-        string? baseUrl = null)
+        string? baseUrl = null,
+        string? cachePath = null,
+        double? timeoutSeconds = null)
     {
         _logger = LoggerFactory.Create(b => b.AddDebug()).CreateLogger<EnvbeeClient>();
 
@@ -82,11 +87,27 @@ public sealed class EnvbeeClient
             _logger.LogDebug("No encryption key provided");
         }
 
-        _cache = new FileCache(_apiKey, _logger);
+        var parsedTimeout = timeoutSeconds.GetValueOrDefault(4);
+        _requestTimeout = TimeSpan.FromSeconds(parsedTimeout > 0 ? parsedTimeout : 4);
+
+        _cache = CreateCacheStore(_apiKey, cachePath);
 
         _logger.LogInformation("EnvbeeClient initialized for {BaseUrl}.", _baseUrl);
     }
     #endregion
+
+    private ICacheStore CreateCacheStore(string apiKey, string? cachePath)
+    {
+        try
+        {
+            return new FileCache(apiKey, _logger, cachePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Cache path is unavailable. Falling back to in-memory cache only.");
+            return new MemoryCacheStore();
+        }
+    }
 
     #region public API
 
@@ -267,8 +288,7 @@ public sealed class EnvbeeClient
             }
             catch (Exception cacheEx)
             {
-                _logger.LogError(cacheEx, "Failed to fill environment variables from API and cache.");
-                throw;
+                _logger.LogWarning(cacheEx, "Failed to fill environment variables from API and cache.");
             }
         }
     }
@@ -326,15 +346,17 @@ public sealed class EnvbeeClient
 
         try
         {
-            using var resp = await _http.SendAsync(req, ct);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(_requestTimeout);
+            using var resp = await _http.SendAsync(req, timeoutCts.Token);
             if (resp.StatusCode == HttpStatusCode.OK)
             {
-                var stream = await resp.Content.ReadAsStreamAsync(ct);
-                var json = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+                var stream = await resp.Content.ReadAsStreamAsync(timeoutCts.Token);
+                var json = await JsonDocument.ParseAsync(stream, cancellationToken: timeoutCts.Token);
                 return json.RootElement.Clone();
             }
 
-            var payload = await resp.Content.ReadAsStringAsync(ct);
+            var payload = await resp.Content.ReadAsStringAsync(timeoutCts.Token);
             throw new RequestException(resp.StatusCode, $"Request failed: {payload}");
         }
         catch (TaskCanceledException) when (!ct.IsCancellationRequested)

--- a/Envbee.SDK/EnvbeeClient.cs
+++ b/Envbee.SDK/EnvbeeClient.cs
@@ -145,6 +145,133 @@ public sealed class EnvbeeClient
 
         return (data, meta!);
     }
+
+    /// <summary>
+    /// Fetch a paginated list of typed variables.
+    /// </summary>
+    public async Task<(IReadOnlyList<Variable> Data, Metadata Meta)> GetVariablesTypedAsync(
+        int? offset = null,
+        int? limit = null,
+        CancellationToken ct = default)
+    {
+        var (rawData, meta) = await GetVariablesAsync(offset, limit, ct);
+        var data = rawData.Select(ParseVariable).ToList();
+        return (data, meta);
+    }
+
+    /// <summary>
+    /// Fetch a paginated list of variables values.
+    /// </summary>
+    public async Task<(IReadOnlyList<JsonElement> Data, Metadata Meta)> GetVariablesValuesAsync(
+        int? offset = null,
+        int? limit = null,
+        CancellationToken ct = default)
+    {
+        var path = "/v1/variables-values";
+        var query = new Dictionary<string, object?>();
+        if (offset.HasValue) query["offset"] = offset;
+        if (limit.HasValue) query["limit"] = limit;
+        path = UrlHelpers.AddQueryString(path, query);
+
+        var json = await SendRequestAsync(path, ct);
+        var meta = JsonSerializer.Deserialize<Metadata>(json.GetProperty("metadata").GetRawText(), serializerOptions);
+        var data = json.GetProperty("data").EnumerateArray().ToList();
+
+        return (data, meta!);
+    }
+
+    /// <summary>
+    /// Fetch a paginated list of typed variable values.
+    /// </summary>
+    public async Task<(IReadOnlyList<VariableValue> Data, Metadata Meta)> GetVariablesValuesTypedAsync(
+        int? offset = null,
+        int? limit = null,
+        CancellationToken ct = default)
+    {
+        var (rawData, meta) = await GetVariablesValuesAsync(offset, limit, ct);
+        var data = rawData.Select(ParseVariableValue).ToList();
+        return (data, meta);
+    }
+
+    /// <summary>
+    /// Fills process environment variables using envbee definitions and values.
+    /// If API calls fail, falls back to locally cached values.
+    /// </summary>
+    public async Task FillEnvVarsAsync(IReadOnlyCollection<string>? variableNames = null, CancellationToken ct = default)
+    {
+        try
+        {
+            var allVariables = (await GetVariablesTypedAsync(ct: ct)).Data;
+            var allValues = (await GetVariablesValuesTypedAsync(ct: ct)).Data
+                .ToDictionary(v => v.VariableId, v => v);
+
+            foreach (var variable in allVariables)
+            {
+                var name = variable.Name;
+
+                if (variableNames is not null && !variableNames.Contains(name))
+                {
+                    _logger.LogDebug("Skipping variable {Var} as it's not in the specified list.", name);
+                    continue;
+                }
+
+                try
+                {
+                    if (!allValues.TryGetValue(variable.Id, out var valueEntry))
+                    {
+                        _logger.LogWarning("Variable {Var} has no associated value entry.", name);
+                        continue;
+                    }
+
+                    if (!valueEntry.Content.TryGetProperty("value", out var rawValue))
+                    {
+                        _logger.LogWarning("Variable {Var} has invalid value payload.", name);
+                        continue;
+                    }
+
+                    if (rawValue.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+                        continue;
+
+                    var finalValue = rawValue.ValueKind == JsonValueKind.String
+                        ? MaybeDecrypt(rawValue.GetString() ?? string.Empty)
+                        : rawValue.ToString();
+
+                    Environment.SetEnvironmentVariable(name, finalValue);
+                    _logger.LogDebug("Set environment variable: {Var}", name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error fetching or setting variable {Var}", name);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fill env vars from API. Falling back to cache.");
+            try
+            {
+                foreach (var kv in _cache.GetAll())
+                {
+                    var name = kv.Key;
+                    if (variableNames is not null && !variableNames.Contains(name))
+                    {
+                        _logger.LogDebug("Skipping variable {Var} as it's not in the specified list.", name);
+                        continue;
+                    }
+
+                    var cached = kv.Value;
+                    var finalValue = MaybeDecrypt(cached);
+                    Environment.SetEnvironmentVariable(name, finalValue);
+                    _logger.LogDebug("Set environment variable from cache: {Var}", name);
+                }
+            }
+            catch (Exception cacheEx)
+            {
+                _logger.LogError(cacheEx, "Failed to fill environment variables from API and cache.");
+                throw;
+            }
+        }
+    }
     #endregion
 
     #region internals
@@ -262,6 +389,35 @@ public sealed class EnvbeeClient
         {
             throw new DecryptionException("Decryption failed. Invalid key or corrupted data.", ex);
         }
+    }
+
+    private static Variable ParseVariable(JsonElement elem)
+    {
+        var id = elem.GetProperty("id").GetInt64();
+        var name = elem.GetProperty("name").GetString()
+            ?? throw new JsonException("Variable name is required.");
+        var typeRaw = elem.GetProperty("type").GetString()
+            ?? throw new JsonException("Variable type is required.");
+
+        if (!Enum.TryParse<VariableType>(typeRaw, ignoreCase: true, out var variableType))
+            throw new JsonException($"Unknown variable type: {typeRaw}");
+
+        string? description = null;
+        if (elem.TryGetProperty("description", out var descriptionElem) &&
+            descriptionElem.ValueKind != JsonValueKind.Null)
+        {
+            description = descriptionElem.GetString();
+        }
+
+        return new Variable(id, variableType, name, description);
+    }
+
+    private static VariableValue ParseVariableValue(JsonElement elem)
+    {
+        var id = elem.GetProperty("id").GetInt64();
+        var variableId = elem.GetProperty("variable_id").GetInt64();
+        var content = elem.GetProperty("content").Clone();
+        return new VariableValue(id, variableId, content);
     }
     #endregion
 }

--- a/Envbee.SDK/EnvbeeClientBuilder.cs
+++ b/Envbee.SDK/EnvbeeClientBuilder.cs
@@ -15,6 +15,8 @@ namespace Envbee.SDK
         private Secret _apiSecret = default;
         private Secret _encKey = default;
         private HttpMessageHandler? _handler;
+        private string? _cachePath;
+        private double? _timeoutSeconds;
 
         private EnvbeeClientBuilder() { }
 
@@ -62,6 +64,24 @@ namespace Envbee.SDK
         }
 
         /// <summary>
+        /// Sets a custom cache directory path.
+        /// </summary>
+        public EnvbeeClientBuilder WithCachePath(string cachePath)
+        {
+            _cachePath = cachePath;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets request timeout in seconds.
+        /// </summary>
+        public EnvbeeClientBuilder WithTimeoutSeconds(double timeoutSeconds)
+        {
+            _timeoutSeconds = timeoutSeconds;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the configured <see cref="EnvbeeClient"/>.
         /// </summary>
         public EnvbeeClient Build()
@@ -75,14 +95,16 @@ namespace Envbee.SDK
                 apiKey: _apiKey,
                 apiSecret: _apiSecret,
                 encKey: _encKey,
-                baseUrl: _baseUrl);
+                baseUrl: _baseUrl,
+                cachePath: _cachePath,
+                timeoutSeconds: _timeoutSeconds);
 
             // If the user provided a custom handler, swap the static HttpClient via reflection.
             if (_handler is not null)
             {
                 if (_handler is not null)
                 {
-                    var custom = new HttpClient(_handler) { Timeout = TimeSpan.FromSeconds(4) };
+                    var custom = new HttpClient(_handler) { Timeout = Timeout.InfiniteTimeSpan };
                     EnvbeeClient.OverrideHttpClient(custom);
                 }
             }

--- a/Envbee.SDK/Interfaces/ICacheStore.cs
+++ b/Envbee.SDK/Interfaces/ICacheStore.cs
@@ -14,4 +14,9 @@ public interface ICacheStore
     /// Sets a value to the internal store
     /// </summary>
     void Set(string key, string value);
+
+    /// <summary>
+    /// Enumerates all cached key/value pairs.
+    /// </summary>
+    IEnumerable<KeyValuePair<string, string>> GetAll();
 }

--- a/Envbee.SDK/Internal/FileCache.cs
+++ b/Envbee.SDK/Internal/FileCache.cs
@@ -63,4 +63,25 @@ internal sealed class FileCache : ICacheStore
             _logger.LogError(ex, "Failed to write cache.");
         }
     }
+
+    public IEnumerable<KeyValuePair<string, string>> GetAll()
+    {
+        try
+        {
+            lock (_lock)
+            {
+                if (!File.Exists(_filePath))
+                    return Enumerable.Empty<KeyValuePair<string, string>>();
+
+                var json = File.ReadAllText(_filePath);
+                var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                return dict?.ToArray() ?? Enumerable.Empty<KeyValuePair<string, string>>();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to enumerate cache.");
+            return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+    }
 }

--- a/Envbee.SDK/Internal/FileCache.cs
+++ b/Envbee.SDK/Internal/FileCache.cs
@@ -14,13 +14,18 @@ internal sealed class FileCache : ICacheStore
     private readonly ILogger _logger;
     private readonly object _lock = new();
 
-    public FileCache(string apiKey, ILogger logger)
+    public FileCache(string apiKey, ILogger logger, string? cachePath = null)
     {
-        var dir = Path.Combine(
+        var dir = cachePath ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "envbee", apiKey, "cache");
 
         Directory.CreateDirectory(dir);
+
+        var probePath = Path.Combine(dir, $".envbee-write-test-{Environment.ProcessId}-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
+        File.WriteAllText(probePath, "ok");
+        File.Delete(probePath);
+
         _filePath = Path.Combine(dir, "variables.json");
         _logger = logger;
     }

--- a/Envbee.SDK/Internal/MemoryCacheStore.cs
+++ b/Envbee.SDK/Internal/MemoryCacheStore.cs
@@ -1,0 +1,15 @@
+using System.Collections.Concurrent;
+using Envbee.SDK.Interfaces;
+
+namespace Envbee.SDK.Internal;
+
+internal sealed class MemoryCacheStore : ICacheStore
+{
+    private readonly ConcurrentDictionary<string, string> _dict = new();
+
+    public string? Get(string key) => _dict.TryGetValue(key, out var value) ? value : null;
+
+    public void Set(string key, string value) => _dict[key] = value;
+
+    public IEnumerable<KeyValuePair<string, string>> GetAll() => _dict.ToArray();
+}

--- a/Envbee.SDK/Variable.cs
+++ b/Envbee.SDK/Variable.cs
@@ -1,0 +1,6 @@
+namespace Envbee.SDK;
+
+/// <summary>
+/// Variable definition.
+/// </summary>
+public sealed record Variable(long Id, VariableType Type, string Name, string? Description);

--- a/Envbee.SDK/VariableType.cs
+++ b/Envbee.SDK/VariableType.cs
@@ -1,0 +1,24 @@
+namespace Envbee.SDK;
+
+/// <summary>
+/// Supported envbee variable types.
+/// </summary>
+public enum VariableType
+{
+    /// <summary>
+    /// String variable.
+    /// </summary>
+    STRING,
+    /// <summary>
+    /// Numeric variable.
+    /// </summary>
+    NUMBER,
+    /// <summary>
+    /// Boolean variable.
+    /// </summary>
+    BOOLEAN,
+    /// <summary>
+    /// JSON variable.
+    /// </summary>
+    JSON
+}

--- a/Envbee.SDK/VariableValue.cs
+++ b/Envbee.SDK/VariableValue.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace Envbee.SDK;
+
+/// <summary>
+/// Variable value entry.
+/// </summary>
+public sealed record VariableValue(long Id, long VariableId, JsonElement Content);

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ using Envbee.SDK;
 var client = new EnvbeeClient(
     apiKey: "your_api_key",
     apiSecret: "your_api_secret",
-    encKey: "encryption-key-goes-here" // optional
+    encKey: "encryption-key-goes-here", // optional
+    timeoutSeconds: 4 // optional, default 4
 );
 
 string? value = await client.GetAsync("VariableName");
@@ -54,6 +55,7 @@ Or using the builder:
 var client = EnvbeeClientBuilder.Create()
     .WithCredentials("your_api_key", "your_api_secret")
     .WithEncryptionKey("32-byte-encryption-key-goes-here")
+    .WithTimeoutSeconds(4)
     .Build();
 ```
 
@@ -114,6 +116,7 @@ The SDK caches variables locally to provide fallback data when offline or the AP
 
 - Encryption key is never stored in cache or sent to API.
 - All encryption/decryption happens locally with AES-256-GCM.
+- If disk cache is unavailable (permission/path issues), the SDK logs a warning and falls back to in-memory cache for the current process.
 
 ## Dependency Injection
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Explicit parameters take precedence over environment variables.
 
 - `Task<object?> GetAsync(string variableName)` — fetches a variable and returns its value as `string`, `decimal`, `int`, `double` or `bool`
 - `Task<(IReadOnlyList<JsonElement> Data, Metadata Meta)> GetVariablesAsync(int? offset = null, int? limit = null)` — fetches variable metadata with pagination
+- `Task<(IReadOnlyList<JsonElement> Data, Metadata Meta)> GetVariablesValuesAsync(int? offset = null, int? limit = null)` — fetches variable values with pagination
+- `Task<(IReadOnlyList<Variable> Data, Metadata Meta)> GetVariablesTypedAsync(int? offset = null, int? limit = null)` — fetches typed variable metadata with pagination
+- `Task<(IReadOnlyList<VariableValue> Data, Metadata Meta)> GetVariablesValuesTypedAsync(int? offset = null, int? limit = null)` — fetches typed variable values with pagination
+- `Task FillEnvVarsAsync(IReadOnlyCollection<string>? variableNames = null)` — sets current process environment variables from Envbee, with cache fallback when API is unavailable
 
 ## Encryption
 


### PR DESCRIPTION
## Summary
This PR introduces a functional upgrade to the Python SDK by adding typed models, expanding variables-values support, and improving environment variable loading workflows.

## What changed
- Added typed dataclasses in `envbee_sdk.model` (including metadata/value models) and removed the old `metadata.py`.
- Extended SDK API support for variables-values endpoints.
- Added `fill_env_vars(variable_names: list[str] | None = None)` helper to load variables into environment variables.
- Improved cache usage/fallback behavior when API calls fail.
- Updated README with new usage examples and data model documentation.
- Expanded tests in `tests/test_main.py`, including coverage for:
  - `fill_env_vars`
  - cache fallback scenarios
- Minor workflow/test script updates in CI-related files.

## Why
These changes make the SDK easier to use in real projects (typed responses + env var bootstrap) and more resilient (cache fallback), while increasing confidence through test coverage.

## Validation
- Unit tests updated for new API/model behavior.
- Added tests specifically for `fill_env_vars` and cache fallback path.
